### PR TITLE
Alternative Plotly CDN

### DIFF
--- a/core/templates/layouts/base-fullscreen.html
+++ b/core/templates/layouts/base-fullscreen.html
@@ -22,7 +22,7 @@
   <link href="/static/assets/css/style.css?v=1.1.0" rel="stylesheet" />
   
   <!-- PlotlyJs CDN -->
-  <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/plotly.js/1.54.5/plotly-mapbox.min.js"></script>
 
   <!-- Specific CSS goes HERE -->
   {% block stylesheets %}{% endblock stylesheets %}

--- a/core/templates/layouts/base.html
+++ b/core/templates/layouts/base.html
@@ -22,7 +22,7 @@
   <link href="/static/assets/css/style.css?v=1.1.0" rel="stylesheet" />
   
   <!-- Plotly.js CDN -->
-  <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/plotly.js/1.54.5/plotly-mapbox.min.js"></script>
   
   <!-- Specific CSS goes HERE -->
   {% block stylesheets %}


### PR DESCRIPTION
Switching from https://cdn.plot.ly/plotly-latest.min.js to https://cdnjs.cloudflare.com/ajax/libs/plotly.js/1.54.5/plotly-mapbox.min.js results in a considerably smaller download size while still retaining the functionality of the maps. 