### PR TITLE
Small performance improvements

### DIFF
--- a/core/templates/includes/scripts.html
+++ b/core/templates/includes/scripts.html
@@ -2,12 +2,6 @@
   <!--   Core   -->
   <script src="/static/assets/js/plugins/jquery/dist/jquery.min.js"></script>
   <script src="/static/assets/js/plugins/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
-  <!--   Optional JS   -->
-  <script src="/static/assets/js/plugins/chart.js/dist/Chart.min.js"></script>
-  <script src="/static/assets/js/plugins/chart.js/dist/Chart.extension.js"></script>
-
-  <!--   G.Maps   -->
-  <script src="https://maps.googleapis.com/maps/api/js?key=YOUR_KEY_HERE"></script>
 
   <!--   Argon JS   -->
   <script src="/static/assets/js/argon-dashboard.min.js?v=1.1.0"></script>

--- a/core/templates/includes/scripts.html
+++ b/core/templates/includes/scripts.html
@@ -1,4 +1,3 @@
-
   <!--   Core   -->
   <script src="/static/assets/js/plugins/jquery/dist/jquery.min.js"></script>
   <script src="/static/assets/js/plugins/bootstrap/dist/js/bootstrap.bundle.min.js"></script>

--- a/core/templates/layouts/base-fullscreen.html
+++ b/core/templates/layouts/base-fullscreen.html
@@ -16,7 +16,7 @@
   <link href="{% static 'assets/img/brand/favicon.ico' %}" rel="icon" type="image/png">
   
   <!-- Fonts -->
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&display=swap" rel="stylesheet">
   <!-- Icons -->
   <script src="https://kit.fontawesome.com/189832a678.js" crossorigin="anonymous"></script>
   <link href="/static/assets/css/style.css?v=1.1.0" rel="stylesheet" />

--- a/core/templates/layouts/base-fullscreen.html
+++ b/core/templates/layouts/base-fullscreen.html
@@ -13,15 +13,20 @@
   </title>
 
   <!-- Favicon - loaded as static -->
-  <link href="{% static 'assets/img/brand/favicon.ico' %}" rel="icon" type="image/png">
-  
+  <link rel="icon" href="{% static 'assets/img/brand/favicon.ico' %}" type="image/png" media="print" onload="this.media='all'"/>
+  <noscript><link rel="icon" href="{% static 'assets/img/brand/favicon.ico' %}" type="image/png"/></noscript>
+
   <!-- Fonts -->
-  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&display=swap" media="print" onload="this.media='all'"/>
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&display=swap"/></noscript>
+
   <!-- Icons -->
-  <script src="https://kit.fontawesome.com/189832a678.js" crossorigin="anonymous"></script>
-  <link href="/static/assets/css/style.css?v=1.1.0" rel="stylesheet" />
-  
-  <!-- PlotlyJs CDN -->
+  <script defer src="https://kit.fontawesome.com/189832a678.js" crossorigin="anonymous"></script>
+
+  <link rel="stylesheet" href="/static/assets/css/style.css?v=1.1.0" media="print" onload="this.media='all'"/>
+  <noscript><link rel="stylesheet" href="/static/assets/css/style.css?v=1.1.0"/></noscript>
+
+  <!-- Plotly.js CDN -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/plotly.js/1.54.6/plotly.min.js"></script>
 
   <!-- Specific CSS goes HERE -->
@@ -54,13 +59,13 @@
         </svg>
       </div>
     </div>
-    
+
     {% block content %}{% endblock content %}
 
     {% include "includes/footer-fullscreen.html" %}
 
   </div>
-    
+
   {% include "includes/scripts-fullscreen.html" %}
 
 </body>

--- a/core/templates/layouts/base.html
+++ b/core/templates/layouts/base.html
@@ -7,26 +7,31 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  
+
   <title>
     COVID-19 Dashboard | {% block title %} Open-Source analytics dashboard {% endblock %}
   </title>
 
   <!-- Favicon - loaded as static -->
-  <link href="{% static 'assets/img/brand/favicon.ico' %}" rel="icon" type="image/png">
-  
+  <link rel="icon" href="{% static 'assets/img/brand/favicon.ico' %}" type="image/png" media="print" onload="this.media='all'"/>
+  <noscript><link rel="icon" href="{% static 'assets/img/brand/favicon.ico' %}" type="image/png"/></noscript>
+
   <!-- Fonts -->
-  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&display=swap" media="print" onload="this.media='all'"/>
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&display=swap"/></noscript>
+
   <!-- Icons -->
-  <script src="https://kit.fontawesome.com/189832a678.js" crossorigin="anonymous"></script>
-  <link href="/static/assets/css/style.css?v=1.1.0" rel="stylesheet" />
-  
+  <script defer src="https://kit.fontawesome.com/189832a678.js" crossorigin="anonymous"></script>
+
+  <link rel="stylesheet" href="/static/assets/css/style.css?v=1.1.0" media="print" onload="this.media='all'"/>
+  <noscript><link rel="stylesheet" href="/static/assets/css/style.css?v=1.1.0"/></noscript>
+
   <!-- Plotly.js CDN -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/plotly.js/1.54.6/plotly.min.js"></script>
-  
+
   <!-- Specific CSS goes HERE -->
   {% block stylesheets %}
-  
+
   {% endblock stylesheets %}
 
 </head>

--- a/core/templates/layouts/base.html
+++ b/core/templates/layouts/base.html
@@ -16,7 +16,7 @@
   <link href="{% static 'assets/img/brand/favicon.ico' %}" rel="icon" type="image/png">
   
   <!-- Fonts -->
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&display=swap" rel="stylesheet">
   <!-- Icons -->
   <script src="https://kit.fontawesome.com/189832a678.js" crossorigin="anonymous"></script>
   <link href="/static/assets/css/style.css?v=1.1.0" rel="stylesheet" />


### PR DESCRIPTION
I've made a couple of small improvements to increase performance according to #52: 

- Unnecessary requests were removed (Open Sans 700, Chart.js, Google Maps API) reducing overall page weight

- Icons, fonts and stylesheets are now loaded asynchronously (only if JavaScript is supported, otherwise they will be loaded the traditional synchronous way) to prevent them from blocking the rendering of the page

- Google Fonts now use font-display: swap allowing the content to be displayed before the fonts have finished loading

These changes result in the page size being slightly reduced from 7.5 MB to 7 MB as well as the loading times from around 4 seconds to 3.5 seconds.