### PR TITLE
World map performance improvements

### DIFF
--- a/core/static/assets/js/fetch-data.js
+++ b/core/static/assets/js/fetch-data.js
@@ -1,10 +1,13 @@
 window.addEventListener("load", function() {
     load_report();
     load_trends();
+    load_world_map();
     load_cases_table();
     load_realtime_growth_chart();
     load_daily_growth_chart();
 });
+
+
 
 function load_report() {
     var xhttp = new XMLHttpRequest();
@@ -23,6 +26,8 @@ function load_report() {
     xhttp.open("GET", "report");
     xhttp.send();
 }
+
+
 
 function load_trends() {
     var xhttp = new XMLHttpRequest();
@@ -83,6 +88,74 @@ function load_trends() {
     xhttp.send();
 }
 
+
+
+function load_world_map() {
+    var xhttp = new XMLHttpRequest();
+
+    xhttp.onreadystatechange = function() {
+        if (this.readyState == 4 && this.status == 200) {
+            var data = JSON.parse(this.response);
+            hoverinfo = function() {
+                result = [];
+
+                for (let index = 0; index < Object.values(data["Combined_Key"]).length; index++) {
+                    result.push(
+                        "<b>" + Object.values(data["Combined_Key"])[index] + "</b><br>" +
+                        "Confirmed: " + Object.values(data["Confirmed"])[index] + "<br>" + 
+                        "Lat: " + Object.values(data["Lat"])[index] + "<br>" +
+                        "Long: " + Object.values(data["Long_"])[index]
+                    );
+                }
+
+                return result;
+            }();
+
+            var plot_data = [{
+                type: "scattermapbox",
+                lat: Object.values(data["Lat"]),
+                lon: Object.values(data["Long_"]),
+                hovertext: hoverinfo,
+                hoverinfo: "text",
+                marker: {
+                    color: Object.values(data["Confirmed"]),
+                    colorbar: {
+                        outlinewidth: 0,
+                        title: {
+                            text: "Confirmed"
+                        }
+                    },
+                    colorscale: "Bluered",
+                    showscale: true,
+                    size: Object.values(data["Confirmed"]),
+                    sizemin: 0,
+                    sizeref: 1000,
+                    sizemode: "area"
+                }
+            }];
+
+            var plot_layout = {
+                margin: {t:0, l:0, r:0, b:0},
+                paper_bgcolor:'rgba(0,0,0,0)',
+                mapbox: {
+                    style: "carto-positron",
+                    center: {lat: 20, lon: -20},
+                    zoom: 1
+                }
+            };
+
+            var plot_config = {responsive: true, displayModeBar: false}
+
+            Plotly.newPlot(document.getElementById("world_map"), plot_data, plot_layout, plot_config);
+        }
+    };
+
+    xhttp.open("GET", "daily_report");
+    xhttp.send();
+}
+
+
+
 function load_cases_table() {
     var xhttp = new XMLHttpRequest();
 
@@ -116,6 +189,8 @@ function load_cases_table() {
     xhttp.open("GET", "cases");
     xhttp.send();
 }
+
+
 
 function load_realtime_growth_chart() {
     var xhttp = new XMLHttpRequest();
@@ -187,6 +262,8 @@ function load_realtime_growth_chart() {
     xhttp.send();
 }
 
+
+
 function load_daily_growth_chart() {
     var xhttp = new XMLHttpRequest();
 
@@ -246,6 +323,8 @@ function load_daily_growth_chart() {
     xhttp.open("GET", "daily_growth");
     xhttp.send();
 }
+
+
 
 function addCommas(input) {
     var number_string = input.toString();

--- a/core/static/assets/js/fetch-data.js
+++ b/core/static/assets/js/fetch-data.js
@@ -125,11 +125,11 @@ function load_world_map() {
                             text: "Confirmed"
                         }
                     },
-                    colorscale: "Bluered",
+                    colorscale: [[0, "hsl(255, 95%, 26%)"], [0.5, "hsl(330, 60%, 50%)"], [1, "hsl(60, 100%, 60%)"]],
                     showscale: true,
                     size: Object.values(data["Confirmed"]),
                     sizemin: 0,
-                    sizeref: 1000,
+                    sizeref: 2000,
                     sizemode: "area"
                 }
             }];

--- a/core/templates/includes/scripts.html
+++ b/core/templates/includes/scripts.html
@@ -4,6 +4,3 @@
 
   <!--   Argon JS   -->
   <script src="/static/assets/js/argon-dashboard.min.js?v=1.1.0"></script>
-
-  <!--   Sortable Tables  -->
-  <script src="/static/assets/js/sorttable.js"></script>

--- a/core/templates/index.html
+++ b/core/templates/index.html
@@ -16,11 +16,7 @@
         <div class="col-xl-8 mb-5 mb-xl-0">  <!-- Global interactive Plotly Mabpox -->
           <div class="card shadow fade-in-bottom">
             <div class="card-body plotly worldmap">
-              <div class="chart">
-                {% autoescape off %}
-                {{ world_map }}
-                {% endautoescape %}
-              </div>
+              <div id="world_map" class="chart" style="height: 100%;"></div>
             </div>
             <div style="position: absolute; padding:1.25rem 1.5rem;">
                 <h6 class="text-uppercase text-muted ls-1 mb-1">Global | Cumulative</h6>

--- a/core/templates/index.html
+++ b/core/templates/index.html
@@ -117,5 +117,12 @@ $('.nav-item a').removeClass('active');
 $('.home-item a').addClass('active');
 </script>
 
-<script src="/static/assets/js/fetch-data.js"></script>
+<!-- Sortable Tables -->
+<script defer src="/static/assets/js/sorttable.js"></script>
+
+<!-- Plotly.js CDN -->
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/plotly.js/1.54.6/plotly.min.js"></script>
+
+<!-- Load and display data -->
+<script defer src="/static/assets/js/fetch-data.js"></script>
 {% endblock javascripts %}

--- a/core/templates/layouts/base.html
+++ b/core/templates/layouts/base.html
@@ -26,9 +26,6 @@
   <link rel="stylesheet" href="/static/assets/css/style.css?v=1.1.0" media="print" onload="this.media='all'"/>
   <noscript><link rel="stylesheet" href="/static/assets/css/style.css?v=1.1.0"/></noscript>
 
-  <!-- Plotly.js CDN -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/plotly.js/1.54.6/plotly.min.js"></script>
-
   <!-- Specific CSS goes HERE -->
   {% block stylesheets %}
 

--- a/core/templates/pages/maps.html
+++ b/core/templates/pages/maps.html
@@ -10,6 +10,8 @@
     <div class="col-xl-12 mb-5 mb-xl-0">  <!-- Global interactive Plotly Mabpox -->
       <div class="card shadow fade-in-bottom">
         <div class="card-body plotly worldmap">
+          <script src="https://cdnjs.cloudflare.com/ajax/libs/plotly.js/1.54.6/plotly.min.js"></script>
+
           <div class="chart">
             {% autoescape off %}
             {{ usa_map }}

--- a/processdata/maps.py
+++ b/processdata/maps.py
@@ -3,40 +3,10 @@
 import json
 from urllib.request import urlopen
 
-import pandas as pd 
-import plotly.express as px
 import plotly.graph_objs as go
-from plotly.graph_objs import Layout
 from plotly.offline import plot
 
 from . import getdata
-
-
-def world_map():
-    # Use following Mapbox token to acces further styling features.
-    # px.set_mapbox_access_token(open('.mapbox_token').read(''))
-    # Reference: https://plotly.com/python/reference/#scattermapbox
-    df = getdata.daily_report()
-    fig = px.scatter_mapbox(
-        df, 
-        lat = 'Lat', lon='Long_', 
-        color = 'Confirmed', 
-        size = 'Confirmed', 
-        hover_name = 'Country_Region', 
-        hover_data = ['Combined_Key','Confirmed'],
-        labels ={ 'Combined_Key':'loc'}, 
-        zoom = 1, 
-        center = {'lat': 20.0, 'lon': -20.0}, height=450
-    )
-
-    fig.update_layout(
-        mapbox_style='carto-positron', 
-        paper_bgcolor='rgba(0,0,0,0)', 
-        margin=dict(t=0, l=0, r=0, b=0)
-    )
-    plot_div = plot(fig, include_plotlyjs=False, output_type='div', config={'displayModeBar': False})
-    
-    return plot_div
 
 
 def usa_map():
@@ -47,7 +17,7 @@ def usa_map():
 
     df = getdata.usa_counties()
     df.drop([2311], inplace=True)
-    
+
     fig = go.Figure(
         go.Choroplethmapbox(
             geojson = counties, 
@@ -58,7 +28,7 @@ def usa_map():
             colorscale = [[0, '#FFFAF4'], [.005, '#FFE4CC'], [.030, '#DC654F'], [.060, '#CA3328'], [.080, '#B80000'], [.100, '#7C100C'], [.150, '#580000'], [.175, '#300000'], [1, '#170707']]
         )
     )
-    
+
     fig.update_layout(
         mapbox_style = 'carto-positron', 
         paper_bgcolor='rgba(0,0,0,0)', 

--- a/processdata/urls.py
+++ b/processdata/urls.py
@@ -8,5 +8,6 @@ urlpatterns = [
     path('trends', views.trends, name='trends'),
     path('cases', views.global_cases, name='cases'),
     path('realtime_growth', views.realtime_growth, name='realtime_growth'),
-    path('daily_growth', views.daily_growth, name='daily_growth')
+    path('daily_growth', views.daily_growth, name='daily_growth'),
+    path('daily_report', views.daily_report, name='daily_report')
 ]

--- a/processdata/views.py
+++ b/processdata/views.py
@@ -8,11 +8,7 @@ from . import getdata, maps
 
 
 def index(request): 
-    world_map_dict = world_map()
-
-    context = dict(**world_map_dict)
-
-    return render(request, template_name='index.html', context=context)
+    return render(request, template_name='index.html')
 
 
 def report(request):
@@ -68,11 +64,11 @@ def realtime_growth(request):
 
 
 def daily_growth(request):
-    df_confirmed = getdata.daily_confirmed()[["date", "World"]]
-    df_deaths = getdata.daily_deaths()[["date", "World"]]
+    df_confirmed = getdata.daily_confirmed()[['date', 'World']]
+    df_deaths = getdata.daily_deaths()[['date', 'World']]
 
-    df_confirmed = df_confirmed.set_index("date")
-    df_deaths = df_deaths.set_index("date")
+    df_confirmed = df_confirmed.set_index('date')
+    df_deaths = df_deaths.set_index('date')
 
     json_string = '{' + \
         '"confirmed": ' + df_confirmed.to_json(orient='columns') + ',' + \
@@ -80,6 +76,12 @@ def daily_growth(request):
     '}'
 
     return HttpResponse(json_string, content_type='application/json')
+
+
+def daily_report(request):
+    df = getdata.daily_report()
+
+    return HttpResponse(df.to_json(orient='columns'), content_type='application/json')
 
 
 def mapspage(request):

--- a/processdata/views.py
+++ b/processdata/views.py
@@ -81,11 +81,7 @@ def daily_growth(request):
 def daily_report(request):
     df = getdata.daily_report()
 
-    print(df)
-    
     df.drop(['FIPS', 'Admin2', 'Province_State', 'Country_Region', 'Last_Update', 'Deaths', 'Recovered', 'Active', 'Incidence_Rate', 'Case-Fatality_Ratio'], axis=1, inplace=True)
-
-    print(df)
 
     return HttpResponse(df.to_json(orient='columns'), content_type='application/json')
 

--- a/processdata/views.py
+++ b/processdata/views.py
@@ -81,6 +81,12 @@ def daily_growth(request):
 def daily_report(request):
     df = getdata.daily_report()
 
+    print(df)
+    
+    df.drop(['FIPS', 'Admin2', 'Province_State', 'Country_Region', 'Last_Update', 'Deaths', 'Recovered', 'Active', 'Incidence_Rate', 'Case-Fatality_Ratio'], axis=1, inplace=True)
+
+    print(df)
+
     return HttpResponse(df.to_json(orient='columns'), content_type='application/json')
 
 


### PR DESCRIPTION
I have made some changes to improve the performance of the world map (#55):

- The world map is now processed asynchronously on the client.
- Plotly, sorttable and fetch-data are loaded in the background resulting in them no longer blocking the rendering of the page.
- Scripts are only loaded on pages which need them (e.g. plotly is no longer loaded on data.html).

These changes contribute to a considerable reduction of loading times on all pages as well as the lighthouse performance score of index.html finally being in the double-digits!

There have also been some small visual changes: First of all, the marker colors look a little different now because I couldn't find a simple way of implementing them the same way as they were before. Furthermore, the layout of the labels which appear when hovering over a marker has been slightly tweaked. If you want, I could try replicating the previous look again. 

Before:
![screenshot before](https://user-images.githubusercontent.com/53840228/89309863-44615000-d674-11ea-9082-f1b05eee3896.png)

After:
![screenshot after](https://user-images.githubusercontent.com/53840228/89309497-c604ae00-d673-11ea-8563-9495dbeb4f67.png)