### PR TITLE
Fix wrong active menu entry in data.html

### DIFF
--- a/core/templates/includes/sidenav.html
+++ b/core/templates/includes/sidenav.html
@@ -68,7 +68,7 @@
             </a>
           </li>
 
-          <li class="nav-item">
+          <li class="nav-item data-item">
             <a class="nav-link text-muted fade-in-left" href="/data.html" target="_blank">
               <i class="fas fa-database"></i>Data
             </a>

--- a/core/templates/pages/data.html
+++ b/core/templates/pages/data.html
@@ -20,4 +20,8 @@
 
 <!-- Specific JS goes HERE -->
 {% block javascripts %}
+<script>
+$('.nav-item a').removeClass('active');
+$('.data-item a').addClass('active');
+</script>
 {% endblock javascripts %}


### PR DESCRIPTION
I just noticed that the active menu entry in data.html is "Home" and not "Data" and fixed this by simply adding the "active"-class to the correct element in the same way as it works in index.html and maps.html.