### PR TITLE
Fixed Bug: Values from Death Column Populated into Recovered Column and Vice Versa

### DIFF
--- a/core/static/assets/js/fetch-data.js
+++ b/core/static/assets/js/fetch-data.js
@@ -174,8 +174,8 @@ function load_cases_table() {
 
                 new_row += "<td class='font-weight-bold'>" + row["Country"] + "</td>";
                 new_row += "<td>" + addCommas(row["Confirmed"]) + "</td>";
-                new_row += "<td>" + addCommas(row["Deaths"]) + "</td>";
                 new_row += "<td>" + addCommas(row["Recovered"]) + "</td>";
+                new_row += "<td>" + addCommas(row["Deaths"]) + "</td>";
                 new_row += "<td>" + (row["Death Rate"]) + "</td>";
                 new_row += "</tr>";
 


### PR DESCRIPTION
Issue: In fetch-data.js file, the global cases table was incorrectly populating values from the death column into the recovered column and vice versa.

Changes Made:
- Fixed the order recovered and death values are added.